### PR TITLE
Tweak TranslucentTaskbar acrylic background TintColor and TintLuminosityOpacity

### DIFF
--- a/Themes/TranslucentTaskbar/README.md
+++ b/Themes/TranslucentTaskbar/README.md
@@ -27,16 +27,16 @@ The theme styles can also be imported manually. To do that, follow these steps:
 ```json
 {
   "controlStyles[0].target": "Rectangle#BackgroundFill",
-  "controlStyles[0].styles[0]": "Fill:=<AcrylicBrush TintColor=\"Transparent\" TintOpacity=\"0\" TintLuminosityOpacity=\"0\" Opacity=\"1\" FallbackColor=\"#70262626\"/>",
+  "controlStyles[0].styles[0]": "Fill:=<AcrylicBrush TintColor=\"Black\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.15\" Opacity=\"1\" FallbackColor=\"#70262626\"/>",
   "controlStyles[1].target": "Rectangle#BackgroundStroke",
   "controlStyles[1].styles[0]": "Visibility=Collapsed",
   "controlStyles[2].target": "MenuFlyoutPresenter",
-  "controlStyles[2].styles[0]": "Background:=<AcrylicBrush TintColor=\"Transparent\" TintOpacity=\"0\" TintLuminosityOpacity=\"0\" Opacity=\"1\" FallbackColor=\"#A0262626\"/>",
+  "controlStyles[2].styles[0]": "Background:=<AcrylicBrush TintColor=\"Black\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.12\" Opacity=\"1\" FallbackColor=\"#A0262626\"/>",
   "controlStyles[2].styles[1]": "BorderThickness=0,0,0,0",
   "controlStyles[2].styles[2]": "CornerRadius=14",
   "controlStyles[2].styles[3]": "Padding=3,4,3,4",
   "controlStyles[3].target": "Border#OverflowFlyoutBackgroundBorder",
-  "controlStyles[3].styles[0]": "Background:=<AcrylicBrush TintColor=\"Transparent\" TintOpacity=\"0\" TintLuminosityOpacity=\"0\" Opacity=\"1\" FallbackColor=\"#A0262626\"/>",
+  "controlStyles[3].styles[0]": "Background:=<AcrylicBrush TintColor=\"Black\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.12\" Opacity=\"1\" FallbackColor=\"#A0262626\"/>",
   "controlStyles[3].styles[1]": "BorderThickness=0,0,0,0",
   "controlStyles[3].styles[2]": "CornerRadius=15",
   "controlStyles[3].styles[3]": "Margin=-2,-2,-2,-2"


### PR DESCRIPTION
Adjust acrylic background effect properties of TranslucentTaskbar theme in order to make the default white text color be more readable when there is a white background behind