### PR TITLE
Make TranslucentTaskbar compatible with XAML thumbnails

### DIFF
--- a/Themes/TranslucentTaskbar/README.md
+++ b/Themes/TranslucentTaskbar/README.md
@@ -26,20 +26,22 @@ The theme styles can also be imported manually. To do that, follow these steps:
 
 ```json
 {
-  "controlStyles[0].target": "Rectangle#BackgroundFill",
+  "controlStyles[0].target": "Taskbar.TaskbarFrame > Grid#RootGrid > Taskbar.TaskbarBackground > Grid > Rectangle#BackgroundFill",
   "controlStyles[0].styles[0]": "Fill:=<AcrylicBrush TintColor=\"Black\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.15\" Opacity=\"1\" FallbackColor=\"#70262626\"/>",
-  "controlStyles[1].target": "Rectangle#BackgroundStroke",
-  "controlStyles[1].styles[0]": "Visibility=Collapsed",
-  "controlStyles[2].target": "MenuFlyoutPresenter",
-  "controlStyles[2].styles[0]": "Background:=<AcrylicBrush TintColor=\"Black\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.12\" Opacity=\"1\" FallbackColor=\"#A0262626\"/>",
-  "controlStyles[2].styles[1]": "BorderThickness=0,0,0,0",
-  "controlStyles[2].styles[2]": "CornerRadius=14",
-  "controlStyles[2].styles[3]": "Padding=3,4,3,4",
-  "controlStyles[3].target": "Border#OverflowFlyoutBackgroundBorder",
+  "controlStyles[1].target": "Taskbar.TaskbarBackground#HoverFlyoutBackgroundControl > Grid > Rectangle#BackgroundFill",
+  "controlStyles[1].styles[0]": "Fill=#C444",
+  "controlStyles[2].target": "Rectangle#BackgroundStroke",
+  "controlStyles[2].styles[0]": "Visibility=Collapsed",
+  "controlStyles[3].target": "MenuFlyoutPresenter",
   "controlStyles[3].styles[0]": "Background:=<AcrylicBrush TintColor=\"Black\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.12\" Opacity=\"1\" FallbackColor=\"#A0262626\"/>",
   "controlStyles[3].styles[1]": "BorderThickness=0,0,0,0",
-  "controlStyles[3].styles[2]": "CornerRadius=15",
-  "controlStyles[3].styles[3]": "Margin=-2,-2,-2,-2"
+  "controlStyles[3].styles[2]": "CornerRadius=14",
+  "controlStyles[3].styles[3]": "Padding=3,4,3,4",
+  "controlStyles[4].target": "Border#OverflowFlyoutBackgroundBorder",
+  "controlStyles[4].styles[0]": "Background:=<AcrylicBrush TintColor=\"Black\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.12\" Opacity=\"1\" FallbackColor=\"#A0262626\"/>",
+  "controlStyles[4].styles[1]": "BorderThickness=0,0,0,0",
+  "controlStyles[4].styles[2]": "CornerRadius=15",
+  "controlStyles[4].styles[3]": "Margin=-2,-2,-2,-2"
 }
 ```
 </details>


### PR DESCRIPTION
Fixes https://github.com/ramensoftware/windows-11-taskbar-styling-guide/issues/172.

> The root cause seems to be the same as this issue: https://github.com/ramensoftware/windhawk-mods/issues/742. Once there's more than one taskbar element with an acrylic background, effects become disabled. The workaround sets a simpler transparent background to the thumbnail previews.

Here's how it looks with the updated theme:

![image](https://github.com/user-attachments/assets/a3c6e48c-5de4-4809-b50c-e3f43f475c5e)

The XAML thumbnails background element tree:

![image](https://github.com/user-attachments/assets/70e970e1-b121-4b2a-8693-ba0feabab029)

@Undisputed00x please review.