### PR TITLE
Make transformation guide consistent with other sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,19 +449,27 @@ You can use transformation styles to translate, rotate, scale, or skew elements.
 
 ### Translate
 
-  `RenderTransform:=<TranslateTransform Y="-15" X="15" />`
+  ```
+  RenderTransform:=<TranslateTransform Y="-15" X="15" />
+  ```
 
   -- or --
 
-  `Transform3D:=<CompositeTransform3D TranslateY="-15" TranslateX="15" TranslateZ="-15" />`
+  ```
+  Transform3D:=<CompositeTransform3D TranslateY="-15" TranslateX="15" TranslateZ="-15" />
+  ```
 
 ### Rotate
 
-  `RenderTransform:=<RotateTransform Angle="15" />`
+  ```
+  RenderTransform:=<RotateTransform Angle="15" />
+  ```
 
   -- or --
 
-  `Transform3D:=<CompositeTransform3D RotationX="-15" RotationY="15" RotationZ="-15" />`
+  ```
+  Transform3D:=<CompositeTransform3D RotationX="-15" RotationY="15" RotationZ="-15" />
+  ```
 
   - `X`: 3D vertical rotation.
   - `Y`: 3D horizontal rotation.
@@ -469,15 +477,21 @@ You can use transformation styles to translate, rotate, scale, or skew elements.
 
 ### Scale
 
-  `RenderTransform:=<ScaleTransform ScaleX="1.5" ScaleY="-1.5" />`
+  ```
+  RenderTransform:=<ScaleTransform ScaleX="1.5" ScaleY="-1.5" />
+  ```
 
   -- or --
 
-  `Transform3D:=<CompositeTransform3D ScaleX="-1.5" ScaleY="1.5" ScaleZ="-1.5" />`
+  ```
+  Transform3D:=<CompositeTransform3D ScaleX="-1.5" ScaleY="1.5" ScaleZ="-1.5" />
+  ```
 
 ### Skew
 
-  `RenderTransform:=<SkewTransform AngleX="-15" AngleY="15" />`
+  ```
+  RenderTransform:=<SkewTransform AngleX="-15" AngleY="15" />
+  ```
 
 ### Other properties
 - Rotate, Scale and Skew:

--- a/README.md
+++ b/README.md
@@ -449,49 +449,49 @@ You can use transformation styles to translate, rotate, scale, or skew elements.
 
 ### Translate
 
-  ```
-  RenderTransform:=<TranslateTransform Y="-15" X="15" />
-  ```
+```
+RenderTransform:=<TranslateTransform X="15" Y="-15" />
+```
 
-  -- or --
+-- or --
 
-  ```
-  Transform3D:=<CompositeTransform3D TranslateY="-15" TranslateX="15" TranslateZ="-15" />
-  ```
+```
+Transform3D:=<CompositeTransform3D TranslateX="15" TranslateY="-15" TranslateZ="-15" />
+```
 
 ### Rotate
 
-  ```
-  RenderTransform:=<RotateTransform Angle="15" />
-  ```
+```
+RenderTransform:=<RotateTransform Angle="15" />
+```
 
-  -- or --
+-- or --
 
-  ```
-  Transform3D:=<CompositeTransform3D RotationX="-15" RotationY="15" RotationZ="-15" />
-  ```
+```
+Transform3D:=<CompositeTransform3D RotationX="-15" RotationY="15" RotationZ="-15" />
+```
 
-  - `X`: 3D vertical rotation.
-  - `Y`: 3D horizontal rotation.
-  - `Z`: 2D rotation.
+- `X`: 3D vertical rotation.
+- `Y`: 3D horizontal rotation.
+- `Z`: 2D rotation.
 
 ### Scale
 
-  ```
-  RenderTransform:=<ScaleTransform ScaleX="1.5" ScaleY="-1.5" />
-  ```
+```
+RenderTransform:=<ScaleTransform ScaleX="1.5" ScaleY="-1.5" />
+```
 
-  -- or --
+-- or --
 
-  ```
-  Transform3D:=<CompositeTransform3D ScaleX="-1.5" ScaleY="1.5" ScaleZ="-1.5" />
-  ```
+```
+Transform3D:=<CompositeTransform3D ScaleX="-1.5" ScaleY="1.5" ScaleZ="-1.5" />
+```
 
 ### Skew
 
-  ```
-  RenderTransform:=<SkewTransform AngleX="-15" AngleY="15" />
-  ```
+```
+RenderTransform:=<SkewTransform AngleX="-15" AngleY="15" />
+```
 
 ### Other properties
 - Rotate, Scale and Skew:

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ You can use transformation styles to translate, rotate, scale, or skew elements.
 > [!TIP]
 > You can mix and match transformations when using `Transform3D`! You can also use `RenderTransform` and `Transform3D` together.
 >
-> For example: `Transform3D:=<CompositeTransform3D TranslateY="-15" RotationZ="15" ScaleX="1.5" />`
+> For example: `Transform3D:=<CompositeTransform3D ScaleX="1.5" TranslateY="-15" RotationZ="15" />`
 
 ### Translate
 


### PR DESCRIPTION
Replaces regular code blocks with the larger ones with the copy button, as the rest of the README uses them.

For example:

`RenderTransform:=<TranslateTransform Y="-15" X="15" />`

⬇️

  ```
  RenderTransform:=<TranslateTransform Y="-15" X="15" />
  ```