### PR TITLE
fix(WindowGlass, Borderless): eliminate white ghost rectangles

### DIFF
--- a/Themes/Borderless/README.md
+++ b/Themes/Borderless/README.md
@@ -46,6 +46,7 @@ controlStyles:
   - target: ScrollViewer > ScrollContentPresenter > Border > Grid
     styles:
       - ColumnDefinitions:=<ColumnDefinitionCollection><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></ColumnDefinitionCollection>
+      - Background=Transparent
       - HorizontalAlignment=Stretch
   - target: Taskbar.TaskbarFrame
     styles:
@@ -67,6 +68,12 @@ controlStyles:
   - target: Windows.UI.Xaml.Shapes.Rectangle#BackgroundStroke
     styles:
       - Visibility=Collapsed
+  - target: Taskbar.TaskbarBackground#BackgroundControl
+    styles:
+      - Opacity=0
+  - target: Taskbar.TaskbarBackground#HoverFlyoutBackgroundControl
+    styles:
+      - Opacity=0
   - target: Microsoft.UI.Xaml.Controls.ItemsRepeater#TaskbarFrameRepeater
     styles:
       - Margin=0,4,0,4

--- a/Themes/WindowGlass/README.md
+++ b/Themes/WindowGlass/README.md
@@ -120,6 +120,12 @@ controlStyles:
   - target: Taskbar.TaskbarBackground#BackgroundControl > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Shapes.Rectangle#BackgroundStroke
     styles:
       - Visibility=Collapsed
+  - target: Taskbar.TaskbarBackground#BackgroundControl
+    styles:
+      - Opacity=0
+  - target: Taskbar.TaskbarBackground#HoverFlyoutBackgroundControl
+    styles:
+      - Opacity=0
   - target: Taskbar.AugmentedEntryPointButton#AugmentedEntryPointButton > Taskbar.TaskListButtonPanel#ExperienceToggleButtonRootPanel
     styles:
       - Margin=0,4,0,4
@@ -146,6 +152,7 @@ controlStyles:
   - target: ':root > ScrollViewer > ScrollContentPresenter > Border > Grid'
     styles:
       - ColumnDefinitions:=<ColumnDefinitionCollection><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></ColumnDefinitionCollection>
+      - Background=Transparent
       - ActualWidth=>containerGridWidth
   - target: SystemTray.ChevronIconView
     styles:
@@ -365,6 +372,12 @@ controlStyles:
   - target: Taskbar.TaskbarBackground#BackgroundControl > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Shapes.Rectangle#BackgroundStroke
     styles:
       - Visibility=Collapsed
+  - target: Taskbar.TaskbarBackground#BackgroundControl
+    styles:
+      - Opacity=0
+  - target: Taskbar.TaskbarBackground#HoverFlyoutBackgroundControl
+    styles:
+      - Opacity=0
   - target: Taskbar.AugmentedEntryPointButton#AugmentedEntryPointButton > Taskbar.TaskListButtonPanel#ExperienceToggleButtonRootPanel
     styles:
       - Margin=0,8,0,8
@@ -553,6 +566,7 @@ controlStyles:
   - target: ':root > ScrollViewer > ScrollContentPresenter > Border > Grid'
     styles:
       - ColumnDefinitions:=<ColumnDefinitionCollection><ColumnDefinition Width="*"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></ColumnDefinitionCollection>
+      - Background=Transparent
       - ActualWidth=>containerGridWidth
 ```
 </details>
@@ -607,6 +621,12 @@ controlStyles:
   - target: Taskbar.TaskbarBackground#BackgroundControl > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Shapes.Rectangle#BackgroundStroke
     styles:
       - Visibility=Collapsed
+  - target: Taskbar.TaskbarBackground#BackgroundControl
+    styles:
+      - Opacity=0
+  - target: Taskbar.TaskbarBackground#HoverFlyoutBackgroundControl
+    styles:
+      - Opacity=0
   - target: Taskbar.AugmentedEntryPointButton#AugmentedEntryPointButton > Taskbar.TaskListButtonPanel#ExperienceToggleButtonRootPanel
     styles:
       - Margin=0,10,0,10


### PR DESCRIPTION
Add Opacity=0 to BackgroundControl and HoverFlyoutBackgroundControl, and Background=Transparent to the root Grid for all WindowGlass variants and the Borderless theme.

These themes use a custom 4-column grid layout where the system's default background shows through the star-sized spacer columns, causing persistent white rectangles (especially visible on auto-hide show/hide). The themes already provide their own background via RootGrid, so the system BackgroundControl elements are redundant and safe to hide.