### PR TITLE
Fix time centering for Windows 11 25H2 build 26200.9278 on FrostyGlass theme

### DIFF
--- a/Themes/FrostyGlass/README.md
+++ b/Themes/FrostyGlass/README.md
@@ -187,10 +187,9 @@ controlStyles:
       - FontFamily=Segoe UI VF
       - Margin=0
       - Padding=0
-      - RenderTransform:=<TranslateTransform X="3.5" Y="2" />
+      - RenderTransform:=<TranslateTransform X="5" Y="2" />
       - Width=Auto
       - MinWidth=Auto
-      - HorizontalAlignment=Left
   - target: TextBlock#DateInnerTextBlock
     styles:
       - Visibility=1


### PR DESCRIPTION
### Summary of Changes
Adjusts the `RenderTransform` style for `TextBlock#TimeInnerTextBlock` target to fix time alignment.

### Description
In the latest update for **Windows 11 25H2 (OS build 26200.9278)**, the default visual layout changed slightly, causing the time text to appear off-center. This update modifies the `RenderTransform` values so the time is correctly centered in its slot.

### Key Changes
* Updated `RenderTransform` properties for `TextBlock#TimeInnerTextBlock`.
* Restored proper text centering on Windows 11 build 26200.9278+.

Before:
<img width="626" height="254" alt="image" src="https://github.com/user-attachments/assets/fbc3faba-0992-4cff-ac2f-90d510d924c6" />

After:
<img width="630" height="292" alt="image" src="https://github.com/user-attachments/assets/a4f7643f-4315-4300-b4dc-364646f39b3f" />
